### PR TITLE
directive to ignore wrong file name warning

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -45,6 +45,7 @@ class ScssFile
 				fullPath = path.resolve dir, relativePath
 				fullPathWrong = path.resolve dir, relativePathWrong
 				shouldCheckForWrongName = false
+				shouldReturn = false
 				if fs.existsSync "#{fullPath}.scss"
 					fullPath = "#{fullPath}.scss"
 				else if fs.existsSync "#{fullPath}.sass"
@@ -73,9 +74,18 @@ class ScssFile
 						isWrongFileName = true
 						fileExt = "sass"
 					if isWrongFileName
+						fullPathWrong += ".#{fileExt}"
 						fileName += ".#{fileExt}"
-						console.log "\x1b[31m", "[scss-dependency] rename file #{fileName} to _#{fileName} (full path: #{fullPathWrong})"
-					return
+
+						wrongFileContents = fs.readFileSync(fullPathWrong)
+						disableWarningsRegExp = new RegExp("/\\*\\s*scss-dependency\\s+disable-filename-warning\\s*\\*/", "gm")
+						if not disableWarningsRegExp.test(wrongFileContents)
+							console.log "\x1b[31m", "[scss-dependency] rename file #{fileName} to _#{fileName} (full path: #{fullPathWrong})"
+							shouldReturn = true
+						else
+							fullPath = fullPathWrong
+
+				return if shouldReturn
 
 				@deps.push fullPath
 				new ScssFile fullPath, _.extend {}, @options,


### PR DESCRIPTION
Когда полез переименовывать уже имеющиеся в кодовой базе "неправильно названные" файлы, столкнулся с тем, что есть сложные зависимости, и некоторые из файлов нельзя переименовать. Например, перестанут генериться некоторые .css-файлы, которые в дальнейшем грузятся на сайт динамически.

К тому же, переименовывать уже имеющиеся файлы — чревато тем, что тестировщикам придётся чуть ли не весь сайт перелопатить.

Ко всему, в SASS ведь правило именования файлов с поджопниками является отчасти рекомендательным. Импортить можно как файлы с `_`, так и без `_` в начале.

И я подумал, что проще и правильнее в данном случае добавить директиву для случаев, когда файл проименован "неправильно", но ты как бы в курсе и говоришь утилите scss-dependency, что всё ок, так и должно быть.

При таком подходе я не меняю те файлы, которые уже есть, и при выкатке на бой тестить ничего не надо. А при добавлении будущих файлов, утилита меня предупредит, и у меня будет выбор, как поступить, переименовывать или нет.